### PR TITLE
fix(rust)!: do not include overlay when importing nixpkgs

### DIFF
--- a/examples/rust-complex/flake.nix
+++ b/examples/rust-complex/flake.nix
@@ -1,5 +1,7 @@
 {
+  inputs.nixify.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nixify.url = github:rvolosatovs/nixify;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs;
 
   outputs = {nixify, ...}:
     nixify.lib.rust.mkFlake {

--- a/lib/rust/mkFlake.nix
+++ b/lib/rust/mkFlake.nix
@@ -76,16 +76,6 @@ with self.lib.rust;
       src = src';
       rustupToolchain = rustupToolchain';
     };
-
-    overlay = let
-      overlay' = final: let
-        attrs = mkAttrs' final;
-      in
-        if attrs ? overlay
-        then attrs.overlay
-        else const {};
-    in
-      final: prev: overlay' final prev;
   in
     self.lib.mkFlake {
       inherit
@@ -173,7 +163,9 @@ with self.lib.rust;
       withOverlays = {overlays, ...} @ cx:
         withOverlays (cx
           // {
-            overlays =
+            overlays = let
+              overlay = final: prev: (mkAttrs' final).overlay prev;
+            in
               overlays
               // {
                 ${pname} = overlay;

--- a/lib/rust/mkFlake.nix
+++ b/lib/rust/mkFlake.nix
@@ -103,7 +103,6 @@ with self.lib.rust;
         ++ [
           rust-overlay.overlays.default
           fenix.overlays.default
-          overlay
         ];
 
       withApps = {

--- a/lib/rust/mkOverlay.nix
+++ b/lib/rust/mkOverlay.nix
@@ -9,6 +9,4 @@ with self.lib.rust;
   args: final: let
     attrs = mkAttrs args final;
   in
-    if attrs ? overlay
-    then attrs.overlay
-    else const {}
+    attrs.overlay

--- a/lib/rust/mkPackages.nix
+++ b/lib/rust/mkPackages.nix
@@ -3,6 +3,4 @@ with self.lib.rust;
   args: pkgs: let
     attrs = mkAttrs args pkgs;
   in
-    if attrs ? packages
-    then attrs.packages
-    else throw "no packages generated for library crate (set `build.workspace = true` if there are binary subcrates in the workspace)"
+    attrs.packages


### PR DESCRIPTION
Turns out that latest `nixpkgs` is not as lazy as one'd hope to. This is a workaround for NixOS/nixpkgs#228173