### PR TITLE
ci(check): only set swap on Linux

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,7 @@ jobs:
         name: rvolosatovs
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Set Swap Space
+      if: ${{ runner.os == 'Linux' }}
       uses: pierotofy/set-swap-space@v1.0
       with:
         swap-size-gb: 10


### PR DESCRIPTION
by some reason the `free` command disappeared from Mac runners