### PR TITLE
fix(rust): support `[[bin]]` without `path`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,4 +28,9 @@ jobs:
       uses: pierotofy/set-swap-space@v1.0
       with:
         swap-size-gb: 10
+    - name: Free Disk Space
+      if: ${{ runner.os == 'Linux' }}
+      uses: jlumbroso/free-disk-space@v1.3.0
+      with:
+        tool-cache: false
     - run: nix flake check -L --show-trace


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-path-field