### PR TITLE
feat(rust): add `doctest` check

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -74,6 +74,7 @@ in
       assert attrs.${system} ? "${name}-x86_64-unknown-linux-musl-oci";
       assert attrs.${system} ? ${name}; x;
   in
+    assert flakes.rust.complex.checks.${system} ? doctest;
     assert flakes.rust.complex.packages.${system} ? default;
     assert flakes.rust.hello-multibin.packages.${system} ? default;
     assert flakes.rust.hello-multibin.packages.${system} ? rust-hello-multibin-wasm32-wasip1;

--- a/examples/rust-complex/flake.nix
+++ b/examples/rust-complex/flake.nix
@@ -14,6 +14,7 @@
 
       build.workspace = true;
       clippy.workspace = true;
+      test.doc = true;
       test.workspace = true;
 
       buildOverrides = {

--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,15 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1728776144,
-        "narHash": "sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg=",
+        "lastModified": 1729273024,
+        "narHash": "sha256-Mb5SemVsootkn4Q2IiY0rr9vrXdCCpQ9HnZeD/J3uXs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f876e3d905b922502f031aeec1a84490122254b7",
+        "rev": "fa8b7445ddadc37850ed222718ca86622be01967",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
-        "ref": "v0.19.1",
         "repo": "crane",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,14 @@
 {
   nixConfig.extra-substituters = [
     "https://nixify.cachix.org"
+    "https://rvolosatovs.cachix.org"
     "https://crane.cachix.org"
     "https://nix-community.cachix.org"
     "https://cache.garnix.io"
   ];
   nixConfig.extra-trusted-public-keys = [
     "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
+    "rvolosatovs.cachix.org-1:eRYUO4OXTSmpDFWu4wX3/X08MsP01baqGKi9GsoAmQ8="
     "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
 
   inputs.advisory-db.flake = false;
   inputs.advisory-db.url = "github:rustsec/advisory-db";
-  inputs.crane.url = "github:ipetkov/crane/v0.19.1";
+  inputs.crane.url = "github:ipetkov/crane";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs-nixos";
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/lib/rust/default.nix
+++ b/lib/rust/default.nix
@@ -128,6 +128,7 @@ in {
 
   defaultTestConfig.allFeatures = false;
   defaultTestConfig.allTargets = false;
+  defaultTestConfig.doc = false;
   defaultTestConfig.excludes = [];
   defaultTestConfig.features = [];
   defaultTestConfig.noDefaultFeatures = false;


### PR DESCRIPTION
Integrate https://github.com/ipetkov/crane/pull/720. Opt-in for now, since attempting to run it on binary crates fails. (as does `cargo test --doc`). Eventually we should probably extend https://github.com/rvolosatovs/nixify/blob/9bec46f250b50a16411a4f76ae4a67a7907c4e39/lib/rust/crateBins.nix to also figure out the libraries that will be built, but just expose this option as an opt-in for now