### PR TITLE
fix: do not override `nixpkgs` in examples

### DIFF
--- a/examples/rust-complex/flake.nix
+++ b/examples/rust-complex/flake.nix
@@ -1,8 +1,5 @@
 {
-  inputs.nixify.inputs.nixpkgs-darwin.follows = "nixpkgs";
-  inputs.nixify.inputs.nixpkgs-nixos.follows = "nixpkgs";
   inputs.nixify.url = "github:rvolosatovs/nixify";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
   outputs = {nixify, ...}:
     nixify.lib.rust.mkFlake {


### PR DESCRIPTION
Doing so without providing `nixpkgs` value introduces non-determinism