### PR TITLE
feat(rust): rework multiarch images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -466,7 +466,7 @@ jobs:
     - run: ${{ matrix.config.test-bin }}
 
   oci-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' }}
     permissions:
       packages: write
@@ -483,9 +483,9 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - run: |
-        nix run -L --show-trace --override-input 'nixify' '.' './examples/rust-hello#build-rust-hello-oci' rust-hello
-        nix profile install --inputs-from . 'nixpkgs#buildah'
-        buildah manifest push --all --format 'v2s2' rust-hello docker://ghcr.io/${{ github.repository_owner }}/nixify:rust-hello-${{ github.sha }}
+        nix build -L --show-trace --override-input 'nixify' '.' './examples/rust-hello#rust-hello-oci'
+        nix profile install --inputs-from . 'nixpkgs#skopeo'
+        skopeo copy --all oci-archive:./result docker://ghcr.io/${{ github.repository_owner }}/nixify:rust-hello-${{ github.sha }}
         docker run ghcr.io/${{ github.repository_owner }}/nixify:rust-hello-${{ github.sha }}
 
   test-linux:

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         }:
         extendDerivations {
           buildInputs = with pkgs; [
-            buildah
+            skopeo
             wasmtime
             zig
           ];


### PR DESCRIPTION
Use `skopeo` instead of the custom `buildah` script.

- generate a multiarch image according to the spec https://github.com/opencontainers/image-spec/blob/main/image-index.md in a flake output
- construct a multiarch `oci-archive` by unpacking the generated, per-target `docker-archive`'s and adding a generated manifest