### PR TITLE
fix(rust): drop dangling references masked by laziness

### DIFF
--- a/lib/rust/mkAttrs.nix
+++ b/lib/rust/mkAttrs.nix
@@ -106,7 +106,6 @@ let
     trace' "callCrane" {
       inherit
         buildArgs
-        checkArgs
         clippyArgs
         docArgs
         testArgs

--- a/lib/rust/mkFlake.nix
+++ b/lib/rust/mkFlake.nix
@@ -190,7 +190,6 @@ self.lib.mkFlake {
           hostRustToolchain
           ;
 
-        buildLib = attrs.lib;
         packages =
           packages // attrPkgs // optionalAttrs (attrPkgs ? ${pname}) { default = attrPkgs.${pname}; };
       }


### PR DESCRIPTION
Two references survived only because Nix never forced them:

- `callCrane`'s `trace'` debug attrset inherits `checkArgs`, which is never bound in the enclosing `let` (it was replaced by `buildArgs`, now used directly for `cargoCheckExtraArgs`). Forcing it would abort with an "undefined variable" error.

- `rust/mkFlake.nix` sets `buildLib = attrs.lib`, but `mkAttrs` returns no `lib` attribute, so the binding is dangling.

Neither is referenced anywhere, so removing them is a no-op for the output while eliminating two latent eval errors.